### PR TITLE
logging/config: Add SMTP setup for error reporting

### DIFF
--- a/ci-based/config.yml
+++ b/ci-based/config.yml
@@ -121,12 +121,28 @@ rq:
           formatter: "standard"
           class: "logging.StreamHandler"
           stream: "ext://sys.stderr"  # Default is stderr
+        smtp:
+          formatter: "standard"
+          class: "zeek_benchmarker.logging.SMTPHandler"
+          level: "ERROR"
+          subject_prefix: "zeek-benchmarker"
+          toaddrs:
+            - arne.welzel@corelight.com
       loggers:
         root:
-          handlers: ["default"]
+          handlers: ["default", "smtp"]
           level: "INFO"
-          propagate: false
 
         zeek_benchmarker.tasks:
           level: "DEBUG"
           propagate: true
+
+
+# SMTP settings used for email.
+smtp:
+  credentials:
+    username: unset
+    password: unset
+  host: email-smtp.us-east-1.amazonaws.com
+  port: 587
+  fromaddr: zeek-benchmarker@zeek.org

--- a/ci-based/tests/test_logging.py
+++ b/ci-based/tests/test_logging.py
@@ -1,0 +1,39 @@
+import logging
+import unittest
+from unittest import mock
+
+import zeek_benchmarker.config
+import zeek_benchmarker.logging
+
+
+@mock.patch("smtplib.SMTP")
+class TestSmtpHandler(unittest.TestCase):
+    cfg = zeek_benchmarker.config.Config(
+        {
+            "smtp": {
+                "credentials": {
+                    "username": "test-smtp-user",
+                    "password": "test-smtp-password",
+                },
+                "host": "test.example.com",
+                "fromaddr": "test@test.example.com",
+            }
+        }
+    )
+
+    def test_error_logging(self, smtp_cls):
+        handler = zeek_benchmarker.logging.SMTPHandler(
+            subject_prefix="test-prefix", toaddrs=["a", "b"], cfg=self.cfg
+        )
+
+        logger = logging.Logger("test-logger")
+        logger.addHandler(handler)
+        logger.error("This is an error")
+
+        smtp_mock = smtp_cls.return_value
+        smtp_mock.login.assert_called_with("test-smtp-user", "test-smtp-password")
+        # Check the email that was sent
+        msg = smtp_mock.send_message.call_args[0][0]
+        self.assertEqual(msg["Subject"], "test-prefix ERROR: This is an error")
+        self.assertEqual(msg["From"], "test@test.example.com")
+        self.assertEqual(msg.get_content(), "This is an error\n")

--- a/ci-based/zeek_benchmarker/config.py
+++ b/ci-based/zeek_benchmarker/config.py
@@ -4,6 +4,12 @@ import typing
 import yaml
 
 
+class SMTPSettings(typing.NamedTuple):
+    mailhost: tuple[str, int]
+    credentials: tuple[str, str]
+    fromaddr: str
+
+
 class Config:
     _config: "Config" = None
 
@@ -27,6 +33,18 @@ class Config:
         Allow dictionary key lookups.
         """
         return self._d.get(k, default)
+
+    @property
+    def smtp_settings(self) -> SMTPSettings:
+        smtp = self["smtp"]
+        mailhost = (smtp["host"], int(smtp.get("port", 587)))
+        credentials = (smtp["credentials"]["username"], smtp["credentials"]["password"])
+
+        return SMTPSettings(
+            mailhost=mailhost,
+            credentials=credentials,
+            fromaddr=smtp["fromaddr"],
+        )
 
 
 def get():

--- a/ci-based/zeek_benchmarker/logging.py
+++ b/ci-based/zeek_benchmarker/logging.py
@@ -1,0 +1,32 @@
+import logging.handlers
+import textwrap
+
+from . import config
+
+
+class SMTPHandler(logging.handlers.SMTPHandler):
+    """
+    Custom SMTPHandler that looks up SMTP credentials in the configuration
+    and dynamically creates the subject.
+    """
+
+    def __init__(
+        self,
+        *,
+        subject_prefix: str,
+        toaddrs: list[str] | str,
+        cfg: config.Config = None,
+    ):
+        self.subject_prefix = subject_prefix
+        cfg = cfg or config.get()
+        super().__init__(
+            toaddrs=toaddrs,
+            subject=None,  # dynamically generated
+            secure=(),  # always secure
+            **cfg.smtp_settings._asdict(),
+        )
+
+    def getSubject(self, record):
+        msg = textwrap.shorten(record.getMessage(), width=120)
+        subject = f"{self.subject_prefix} {record.levelname}: {msg}"
+        return subject


### PR DESCRIPTION
Basically, use logging.handlers.SMTPHandler directly so that there's some out-of-band signal when errors happen.