### PR TITLE
WebSocket and logging test maintenance

### DIFF
--- a/ci-based/config-tests.yml
+++ b/ci-based/config-tests.yml
@@ -41,6 +41,13 @@ ZEEK_TESTS:
   - id: pcap-quic-12k
     pcap_file: quic-12k-connections.pcap
 
+  - id: pcap-websocket-traffic-mix
+    pcap_file: websocket-traffic-mix.pcap
+
+  - id: pcap-spicy-websocket-traffic-mix
+    pcap_file: websocket-traffic-mix.pcap
+    pcap_args: 'WebSocket::use_spicy_analyzer=T'
+
   - id: micro-misc-zeek-version
     bench_command: /benchmarker/scripts/tiny-benchmark.sh
     bench_args: -D -b microbenchmarks/misc/zeek-version.zeek

--- a/ci-based/scripts/microbenchmarks/logging/one-stream.zeek
+++ b/ci-based/scripts/microbenchmarks/logging/one-stream.zeek
@@ -1,5 +1,7 @@
 @load base/frameworks/logging
 
+redef exit_only_after_terminate = T;
+
 redef enum Log::ID += { LOG };
 
 type Info: record {
@@ -8,7 +10,7 @@ type Info: record {
 	vec: vector of count;
 };
 
-global n = 1000000;
+global n = 3000000;
 global gmsg = "<msg>";
 global gvec = vector(1, 2, 3);
 
@@ -18,6 +20,8 @@ event do_log(n: count)
 
 	if (--n > 0)
 		event do_log(n);
+	else
+		terminate();
 	}
 
 event zeek_init()

--- a/ci-based/scripts/microbenchmarks/logging/two-streams.zeek
+++ b/ci-based/scripts/microbenchmarks/logging/two-streams.zeek
@@ -1,5 +1,7 @@
 @load base/frameworks/logging
 
+redef exit_only_after_terminate = T;
+
 redef enum Log::ID += { LOG, LOG2 };
 
 type Info: record {
@@ -8,7 +10,7 @@ type Info: record {
 	vec: vector of count;
 };
 
-global n = 1000000;
+global n = 3000000;
 global gmsg = "<msg>";
 global gvec = vector(1, 2, 3);
 
@@ -19,6 +21,8 @@ event do_log(n: count)
 
 	if (--n > 0)
 		event do_log(n);
+	else
+		terminate();
 	}
 
 event zeek_init()


### PR DESCRIPTION
The logging micro-benchmark change will skew the results, but unclear how useful the previous once were anyhow. Might make sense to keep a hash of the micro-benchmark file in the results though to detect something like that.

Relates to https://github.com/zeek/zeek/issues/3331