### PR TITLE
ci-based: always restart redis

### DIFF
--- a/ci-based/docker-compose.yml
+++ b/ci-based/docker-compose.yml
@@ -90,6 +90,7 @@ services:
     build:
       context: .
       dockerfile: containers/redis.Dockerfile
+    restart: always
 
   test-http:
     # HTTP service for faster fetching local builds.


### PR DESCRIPTION
The os-perf-1 system was power cycled and the redis service not automatically started. Fix that for the future.