### PR TITLE
requirements: Bump docker to 7.1.0

### DIFF
--- a/ci-based/requirements.txt
+++ b/ci-based/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.3.3
 PyYAML==6.0.1
 alembic==1.12.0
 docker-pycreds==0.4.0
-docker==6.1.3
+docker==7.1.0
 gunicorn==22.0.0
 requests==2.32.2
 rq==1.15.1


### PR DESCRIPTION
This is to fix requests 2.32.0 not being compatible with docker 6.1.3, raising errors like:

    api-1        | 172.18.0.1 - - [24/Jul/2024:08:51:03 +0000] "POST /zeek?branch=my-testing ... HTTP/1.1" 200 100 "-" "python-requests/2.31.0"
    rq-1         |     raise InvalidURL(e, request=request)
    rq-1         | requests.exceptions.InvalidURL: Not supported URL scheme http+docker

https://github.com/docker/docker-py/pull/3257#issuecomment-2173911243