### PR TITLE
ci-based: Add 500k-syns-slow.pcap test

### DIFF
--- a/ci-based/config-tests.yml
+++ b/ci-based/config-tests.yml
@@ -35,6 +35,9 @@ ZEEK_TESTS:
   - id: pcap-500k-syns
     pcap_file: 500k-syns.pcap
 
+  - id: pcap-500k-syns-slow
+    pcap_file: 500k-syns-slow.pcap
+
   - id: pcap-quic-16-50mb
     pcap_file: quic-16-50mb-transfers.pcap
 


### PR DESCRIPTION
This has a 10x lower packet rate at 10kpps compared to the existing 500k-syns.pcap packets which is at 100kpps.