### PR TITLE
zeek-runner: Add libzmq5 to image

### DIFF
--- a/ci-based/Dockerfile
+++ b/ci-based/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-install-recommends -y \
     iproute2 \
     libmaxminddb0 \
+    libzmq5 \
     linux-tools-common \
     openssl \
     python3 \


### PR DESCRIPTION
Zeek's CI will start to build Zeek with a ZeroMQ dependency going forward. Make sure it's available in the runner image.