### PR TITLE
microbenchmarks: Add Intel::insert() microbenchmark

### DIFF
--- a/ci-based/config-tests.yml
+++ b/ci-based/config-tests.yml
@@ -163,3 +163,11 @@ ZEEK_TESTS:
   - id: micro-events-schedule-batch
     bench_command: /benchmarker/scripts/tiny-benchmark.sh
     bench_args: -D -b microbenchmarks/events/schedule-batch.zeek
+
+  - id: micro-intel-insert-50000
+    bench_command: /benchmarker/scripts/tiny-benchmark.sh
+    bench_args: -D -b microbenchmarks/intel/insert.zeek Test::num_indicators=50000
+
+  - id: micro-intel-insert-500000
+    bench_command: /benchmarker/scripts/tiny-benchmark.sh
+    bench_args: -D -b microbenchmarks/intel/insert.zeek Test::num_indicators=500000

--- a/ci-based/scripts/microbenchmarks/intel/insert.zeek
+++ b/ci-based/scripts/microbenchmarks/intel/insert.zeek
@@ -1,0 +1,35 @@
+# Insert indicators for tracking memory consumption
+@load base/frameworks/intel
+
+module Test;
+
+export {
+	const num_indicators: count = 0 &redef;
+}
+
+event zeek_init()
+	{
+	local i = 0;
+	local meta = Intel::MetaData($source="src");
+	local av = vector(0);
+	while ( i < num_indicators )
+		{
+		local a = i % 256;
+		local b = (i / 256) % 256;
+		local c = (i / 256 / 256) % 256;
+		av[0] = (c << 16) | ( b << 8) | a;
+		local av_addr = counts_to_addr(av);
+
+
+		local aitem= Intel::Item($indicator=cat(av_addr), $indicator_type=Intel::ADDR, $meta=meta);
+		Intel::insert(aitem);
+
+		local sitem= Intel::Item($indicator=cat(av_addr) + "/32", $indicator_type=Intel::SUBNET, $meta=meta);
+		Intel::insert(sitem);
+
+		local user = "user_" + cat(i);
+		local uitem= Intel::Item($indicator=user, $indicator_type=Intel::USER_NAME, $meta=meta);
+		Intel::insert(uitem);
+		++i;
+		}
+	}


### PR DESCRIPTION
Sometimes, users report memory consumption of the Intel framework with many indicators as a concern. This PR adds a microbenchmark such that we start tracking memory usage for 50k and 500k host, subnet and string indicators over time to capture potential regressions if any of the involved data structures change. This isn't so much about execution time, but more about memory usage.