### PR TITLE
ci-based: Add libnode109 to Zeek image

### DIFF
--- a/ci-based/Dockerfile
+++ b/ci-based/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:24.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-install-recommends -y \
     iproute2 \
-    libmaxminddb0 \
     libhiredis1.1.0 \
+    libmaxminddb0 \
+    libnode109 \
     libzmq5 \
     linux-tools-common \
     openssl \


### PR DESCRIPTION
After adding libnode-dev to the Ubuntu 24.04 build on zeek/zeek, running the benchmarks requires libnode109 to exist.